### PR TITLE
Apply chmod to mergedoc

### DIFF
--- a/.github/workflows/merge-docs.yml
+++ b/.github/workflows/merge-docs.yml
@@ -10,8 +10,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Permission
-        run: git update-index --chmod=+x ./.github/scripts/mergedoc.sh
       - name: Merge docs
         run: ./.github/scripts/mergedoc.sh
       - name: Commit merged docs


### PR DESCRIPTION
So the permission step is no longer needed.

In some weird situations, Github Actions may not agree.

It also seems that I added a newline at the end. That's good.

<details>
<summary>Do not open</summary>

_Actually, I didn't apply anything. You did without even knowing since the merge docs action was prepared to commit and push any changed file (I was lazy to filter), and it pushed the `chmod` itself._

</details>

This at least works [here](https://github.com/altrisi/carpet-discarpet/runs/1623483780).