### PR TITLE
Gradle 7, Java 16 build compatibility and Github Actions

### DIFF
--- a/.github/workflows/build-on-pr.yml
+++ b/.github/workflows/build-on-pr.yml
@@ -1,0 +1,33 @@
+# This workflow will build a Java project with Gradle
+# For more information see: https://help.github.com/actions/language-and-framework-guides/building-and-testing-java-with-gradle
+
+name: Pull Request Builds
+
+on: [pull_request]
+
+jobs:
+  Build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up JDK 16
+      uses: actions/setup-java@v2
+      with:
+        distribution: 'adopt'
+        java-version: 16
+    - name: Cache Gradle packages
+      uses: actions/cache@v2
+      with:
+        path: ~/.gradle/caches
+        key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}
+        restore-keys: ${{ runner.os }}-gradle
+    - name: Grant execute permission to gradlew
+      run: chmod +x gradlew
+    - name: Build with Gradle
+      run: ./gradlew build
+    - uses: actions/upload-artifact@v2
+      with:
+        name: "Compiled artifacts for Pull Request #${{github.event.number}}"
+        path: build/libs

--- a/.github/workflows/devbuild.yml
+++ b/.github/workflows/devbuild.yml
@@ -1,0 +1,33 @@
+# This workflow will build a Java project with Gradle
+# For more information see: https://help.github.com/actions/language-and-framework-guides/building-and-testing-java-with-gradle
+
+name: Development Builds
+
+on: [push]
+
+jobs:
+  Build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up JDK 16
+      uses: actions/setup-java@v2
+      with:
+        distribution: 'adopt'
+        java-version: 16
+    - name: Cache Gradle packages
+      uses: actions/cache@v2
+      with:
+        path: ~/.gradle/caches
+        key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}
+        restore-keys: ${{ runner.os }}-gradle
+    - name: Grant execute permission to gradlew
+      run: chmod +x gradlew
+    - name: Build with Gradle
+      run: ./gradlew build
+    - uses: actions/upload-artifact@v2
+      with:
+        name: Compiled artifacts for ${{ github.sha }}
+        path: build/libs

--- a/build.gradle
+++ b/build.gradle
@@ -50,8 +50,6 @@ dependencies {
 	include "com.vdurmont:emoji-java:5.1.1"
 
 
-
-
 	include "com.squareup.okhttp3:okhttp:3.9.1"
 	include "com.squareup.okhttp3:logging-interceptor:3.9.1"
 	include "com.fasterxml.jackson.core:jackson-databind:2.9.3"
@@ -60,53 +58,19 @@ dependencies {
 	include "com.neovisionaries:nv-websocket-client:2.6"
 	include "com.squareup.okio:okio:1.13.0"
 	include "org.json:json:20170516"
-	/*
-	modCompile "org.javacord:javacord-api:${project.javacord_version}"
-	modCompile "org.javacord:javacord-core:${project.javacord_version}"
-	include "org.javacord:javacord-api:${project.javacord_version}"
-	include "org.javacord:javacord-api:${project.javacord_version}"
-	include "org.javacord:javacord-core:${project.javacord_version}"
-*/
-
-	/*
-	//modCompile "com.fasterxml.jackson.core:jackson-databind:2.12.0-rc2"
-	//modCompile "com.fasterxml.jackson.core:jackson-annotations:2.12.0-rc2"
-	//modCompile "com.fasterxml.jackson.core:jackson-core:2.12.0-rc2"
-	include "com.fasterxml.jackson.core:jackson-databind:2.12.0-rc2"
-	include "com.fasterxml.jackson.core:jackson-annotations:2.12.0-rc2"
-	include "com.fasterxml.jackson.core:jackson-core:2.12.0-rc2"
-
-
-
-	include "com.squareup.okhttp3:okhttp:3.9.1"
-	include "com.squareup.okhttp3:logging-interceptor:3.9.1"
-
-	include "com.neovisionaries:nv-websocket-client:2.6"
-	include "com.squareup.okio:okio:1.13.0"
-	include "org.json:json:20170516"
-
-
-
-	 */
+	
 	implementation 'org.apache.logging.log4j:log4j-core:2.14.1'
 	include "org.apache.logging.log4j:log4j-core:2.14.1"
 	include "org.apache.logging.log4j:log4j-api:2.14.1"
 	//include "'org.apache.logging.log4j:log4j-core:jar:2.13.3'"
-
-
 
 }
 
 processResources {
 	inputs.property "version", project.version
 
-	from(sourceSets.main.resources.srcDirs) {
-		include "fabric.mod.json"
-		expand "version": project.version
-	}
-
-	from(sourceSets.main.resources.srcDirs) {
-		exclude "fabric.mod.json"
+	filesMatching("fabric.mod.json") {
+		expand "version": project.mod_version
 	}
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-	id 'fabric-loom' version '0.4-SNAPSHOT'
+	id 'fabric-loom' version '0.7-SNAPSHOT'
 	id 'maven-publish'
 }
 
@@ -24,15 +24,15 @@ dependencies {
 	//to change the versions see the gradle.properties file
 	minecraft "com.mojang:minecraft:${project.minecraft_version}"
 	mappings "net.fabricmc:yarn:${project.yarn_mappings}:v2"
-	modCompile "net.fabricmc:fabric-loader:${project.loader_version}"
-	modCompile "carpet:fabric-carpet:${project.carpet_minecraft_version}-${project.carpet_core_version}"
+	modImplementation "net.fabricmc:fabric-loader:${project.loader_version}"
+	modImplementation "carpet:fabric-carpet:${project.carpet_minecraft_version}-${project.carpet_core_version}"
 
 	// PSA: Some older mods, compiled on Loom 0.2.1, might have outdated Maven POMs.
 	// You may need to force-disable transitiveness on them.
 	//discord
 
-	modCompile "org.javacord:javacord-api:${project.javacord_version}"
-	modCompile "org.javacord:javacord-core:${project.javacord_version}"
+	modImplementation "org.javacord:javacord-api:${project.javacord_version}"
+	modImplementation "org.javacord:javacord-core:${project.javacord_version}"
 
 	include "org.javacord:javacord-api:${project.javacord_version}"
 	include "org.javacord:javacord-core:${project.javacord_version}"
@@ -46,7 +46,7 @@ dependencies {
 	//modCompile "io.vavr:vavr:0.10.1"
 	include "io.vavr:vavr:0.10.1"
 
-	modCompile "com.vdurmont:emoji-java:5.1.1"
+	modImplementation "com.vdurmont:emoji-java:5.1.1"
 	include "com.vdurmont:emoji-java:5.1.1"
 
 
@@ -88,7 +88,7 @@ dependencies {
 
 
 	 */
-	compile 'org.apache.logging.log4j:log4j-core:2.14.1'
+	implementation 'org.apache.logging.log4j:log4j-core:2.14.1'
 	include "org.apache.logging.log4j:log4j-core:2.14.1"
 	include "org.apache.logging.log4j:log4j-api:2.14.1"
 	//include "'org.apache.logging.log4j:log4j-core:jar:2.13.3'"

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.5.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
This PR updates Gradle to 7 and Loom to 0.7, allowing to build the mod with Java 16, and adds Github Actions to build and create those green checks on push and in pull requests, so you make sure you are not merging broken code.

Also cleans up a few of the commented lines in build.gradle, can revert if you want those.