### PR TITLE
Support for skins set from fabrictailor

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -61,6 +61,10 @@ dependencies {
 	
 	modCompileOnly 'maven.modrinth:scarpet-graphics:0.1.4'
 	runtimeOnly 'maven.modrinth:scarpet-graphics:0.1.4'
+
+
+	// FabricTailor (custom player skins)
+	modCompileOnly 'maven.modrinth:fabrictailor:1.8.4'
 }
 
 processResources {

--- a/src/main/java/Discarpet/Discarpet.java
+++ b/src/main/java/Discarpet/Discarpet.java
@@ -6,6 +6,7 @@ import Discarpet.config.BotConfig;
 import Discarpet.config.ConfigManager;
 import Discarpet.script.events.DiscordEvents;
 import Discarpet.script.events.MiscEvents;
+import Discarpet.script.functions.FabricTailorSkins;
 import Discarpet.script.util.Registration;
 import carpet.CarpetExtension;
 import carpet.CarpetServer;
@@ -67,6 +68,11 @@ public class Discarpet implements CarpetExtension, ModInitializer {
 		loadConfig(null);
 		
 		CarpetServer.manageExtension(this);
+
+		if (FabricLoader.getInstance().isModLoaded("fabrictailor")) {
+			FabricTailorSkins.init();
+		}
+
 		Discarpet.LOGGER.info("Discarpet loaded");
 	}
 

--- a/src/main/java/Discarpet/script/functions/FabricTailorSkins.java
+++ b/src/main/java/Discarpet/script/functions/FabricTailorSkins.java
@@ -1,0 +1,60 @@
+package Discarpet.script.functions;
+
+import carpet.script.annotation.AnnotationParser;
+import carpet.script.annotation.ScarpetFunction;
+import com.google.gson.JsonParser;
+import net.minecraft.server.network.ServerPlayerEntity;
+import org.samo_lego.fabrictailor.casts.TailoredPlayer;
+
+import java.util.Base64;
+
+public class FabricTailorSkins {
+
+    public static final String STEVE = "MHF_STEVE";
+
+    public static void init() {
+        AnnotationParser.parseFunctionClass(FabricTailorSkins.class);
+    }
+
+
+    /**
+     * Helper function to get texture hash from skin
+     * that was set with FabricTailor mod.
+     * <p>
+     * Can be used with <a href="https://mc-heads.net/avatar/{textureid}">https://mc-heads.net/avatar/%7Btextureid%7D</a>
+     * to get the head texture.
+     * </p>
+     *
+     * @param player Player to get skin for
+     * @return player's skin id (hash)
+     */
+    @ScarpetFunction
+    public String dc_get_fabrictailor_skin_id(ServerPlayerEntity player) {
+        String skin = ((TailoredPlayer) player).getSkinValue();
+
+        if (skin == null) {
+            // Fallback to default skin
+            var textures = player.getGameProfile().getProperties().get("textures").stream().findAny();
+
+            if (textures.isPresent()) {
+                skin = textures.get().getValue();
+            } else {
+                return STEVE;
+            }
+        }
+
+        // Parse base64 skin
+        String decoded = new String(Base64.getDecoder().decode(skin));
+
+        // Parse as json, then get textures -> SKIN -> url value
+        String url = JsonParser.parseString(decoded)
+                .getAsJsonObject()
+                .getAsJsonObject("textures")
+                .getAsJsonObject("SKIN")
+                .getAsJsonPrimitive("url")
+                .getAsString();
+
+        // Extract id from url
+        return url.substring(url.lastIndexOf('/') + 1);
+    }
+}


### PR DESCRIPTION
Hi there!

I've added a scarpet function for getting data for [fabrictailor](https://modrinth.com/mod/fabrictailor) skins (`dc_getFabricTailorSkinId(player)`). If said mod is installed on server, it allows players to set their skins on that server only. Due to account skin not being changed, the api still returns the same skin for the discord webhook. That's why we can use texture hash / id together with mc-heads api to get the skin player is actually using on the server.

https://mc-heads.net/avatar/{texture_id} supports getting heads for all the skins that were generated once.

Here's also a video with demonstration:

https://user-images.githubusercontent.com/34912839/184632749-cd974acf-3fee-4a84-b6c8-020965535a2e.mp4

Getting the avatar:
```python
// assume 'player' is passed as a parameter to function call
avatar_url = str('https://mc-heads.net/avatar/%s.png',dc_getFabricTailorSkinId(player));
```

 