### PR TITLE
Update for breaking changes in Carpet for 1.19.4

### DIFF
--- a/src/main/java/net/replaceitem/discarpet/script/values/common/DiscordValue.java
+++ b/src/main/java/net/replaceitem/discarpet/script/values/common/DiscordValue.java
@@ -33,7 +33,7 @@ public abstract class DiscordValue<T> extends Value {
         if(toClass == null) throw new InternalExpressionException("Could not find an interface for an output converter for DiscordValue.of() and type " + object.getClass());
         OutputConverter<Object> converter = getOutputConverter(toClass);
         if(converter == null) throw new InternalExpressionException("Could not find a suitable output converter for DiscordValue.of() and type " + object.getClass());
-        return converter.convert(object).evalValue(null);
+        return converter.convert(object);
     }
 
     private static <V> OutputConverter<V> getOutputConverter(Class<V> inputClass) {


### PR DESCRIPTION
This PR changes the usage of `OutputConverter` for breaking changes in the next Carpet release (https://github.com/gnembon/fabric-carpet/commit/883d887e110992b7f8a7718ec5aae2398b66a3b4).

Won't work with current Carpet versions.