### PR TITLE
Added new intent to documentation

### DIFF
--- a/docs/include/warning-script-permissions.md
+++ b/docs/include/warning-script-permissions.md
@@ -1,0 +1,2 @@
+!!! warning "Requires extra permissions"
+    To use this example script your bot will require additional intents. You can add these inside `discarpet.json`

--- a/docs/include/warning-script-permissions.md
+++ b/docs/include/warning-script-permissions.md
@@ -1,2 +1,0 @@
-!!! warning "Requires extra permissions"
-    To use this example script your bot will require additional intents. You can add these inside `discarpet.json`

--- a/docs/pages/examples/chat.md
+++ b/docs/pages/examples/chat.md
@@ -2,7 +2,8 @@ This script sends chat messages in minecraft to the configured
 `global_chat` channel, and messages in that
 channel to the minecraft chat.
 
-{% include 'warning-script-permissions.md' %}
+!!! warning "Requires privileged intents"
+    To use this example script, your bot will require the `MESSAGE_CONTENT` intent. You can add these inside `discarpet.json` as described in [Getting started](/setup.md#intents).
 
 ```sc title="chat.sc"
 __config() -> {'scope'->'global','bot'->'BOT'};

--- a/docs/pages/examples/chat.md
+++ b/docs/pages/examples/chat.md
@@ -2,6 +2,8 @@ This script sends chat messages in minecraft to the configured
 `global_chat` channel, and messages in that
 channel to the minecraft chat.
 
+{% include 'warning-script-permissions.md' %}
+
 ```sc title="chat.sc"
 __config() -> {'scope'->'global','bot'->'BOT'};
 

--- a/docs/pages/examples/reply.md
+++ b/docs/pages/examples/reply.md
@@ -1,5 +1,8 @@
 Directly replies to all messages with a text of `Ping`
 
+!!! warning "Requires privileged intents"
+    To use this example script, your bot will require the `MESSAGE_CONTENT` intent. You can add these inside `discarpet.json` as described in [Getting started](/setup.md#intents).
+
 ```sc title="reply.sc"
 __config() -> {'scope'->'global','bot'->'BOT'};
 

--- a/docs/pages/setup.md
+++ b/docs/pages/setup.md
@@ -110,9 +110,10 @@ the bot from the config will be applied.
 In the config file, you can enable privileged intents for your bot.
 By default, all non-privileged intents are enabled.
 The only privileged intents that are disabled by default are:
- - MESSAGE_CONTENT
- - GUILD_MEMBERS
- - GUILD_PRESENCES
+
+- MESSAGE_CONTENT
+- GUILD_MEMBERS
+- GUILD_PRESENCES
 
 If you add these intents to the `intents` list in your bot config,
 you will also need to enable them in the [Discord developer portal](https://discord.com/developers/applications)

--- a/docs/pages/setup.md
+++ b/docs/pages/setup.md
@@ -109,7 +109,10 @@ the bot from the config will be applied.
 
 In the config file, you can enable privileged intents for your bot.
 By default, all non-privileged intents are enabled.
-The only privileged intents that are disabled by default are `GUILD_PRESENCES` and `GUILD_MEMBERS`.
+The only privileged intents that are disabled by default are:
+ - MESSAGE_CONTENT
+ - GUILD_MEMBERS
+ - GUILD_PRESENCES
 
 If you add these intents to the `intents` list in your bot config,
 you will also need to enable them in the [Discord developer portal](https://discord.com/developers/applications)


### PR DESCRIPTION
Since discord officially flipped the switch on the MESSAGE_CONTENT intent being required back in 2022, the documentation has become slightly out of date. This corrects the missing intent in https://replaceitem.github.io/carpet-discarpet/setup/#intents

I also chose to include a warning in the "chat" example script, stating that the user will need to add a new intent to discarpet.json to use it. I feel that it's more likely for new users to get stuck, as that's one of the first examples they'll try to run. (At least according to the case study of 1 that I participated in :P)

If the maintainer feels that the additional context is unnecessary, remove commit 7b9e9fd203ab5d45d2e97810a6d90cf20a43fc86 . The other commit contains only the corrections