### PR TITLE
Move event startup to `onGameStarted`

### DIFF
--- a/src/main/java/net/replaceitem/discarpet/Discarpet.java
+++ b/src/main/java/net/replaceitem/discarpet/Discarpet.java
@@ -55,9 +55,6 @@ public class Discarpet implements CarpetExtension, ModInitializer {
 
 	@Override
 	public void onInitialize() {
-		DiscordEvents.noop();
-		MiscEvents.noop();
-
 		try {
 			Path configDir = FabricLoader.getInstance().getConfigDir().normalize();
 			Files.createDirectories(configDir);
@@ -76,6 +73,8 @@ public class Discarpet implements CarpetExtension, ModInitializer {
 
 	@Override
 	public void onGameStarted() {
+		DiscordEvents.noop();
+		MiscEvents.noop();
 		Registration.registerValueCasters();
 		Registration.registerDiscordValues();
 		Registration.registerMisc();


### PR DESCRIPTION
Not tested.

Prevents Discarpet from initializing the event system before other mods entities are registered, preventing the log spam when these spawn and making them usable in scarpet. I think this kind of early init is still an issue with Carpet.

By loading them at `onGameStarted`, the `ModInitializer` from all mods has already ran, so it's safe for Carpet to store a definitive list of entities at init.